### PR TITLE
fix: remove AOT publish trimming from release script

### DIFF
--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -122,7 +122,7 @@ if (-not $SkipValidation) {
     Invoke-Step -Name "Restore" -Command "dotnet restore NativeData.slnx"
     Invoke-Step -Name "Build" -Command "dotnet build NativeData.slnx -c Release -warnaserror --no-restore"
     Invoke-Step -Name "Test" -Command "dotnet test NativeData.slnx -c Release --no-build"
-    Invoke-Step -Name "AOT smoke publish" -Command "dotnet publish samples/NativeData.AotSmoke/NativeData.AotSmoke.csproj -c Release -r $RuntimeIdentifier -p:PublishAot=true -p:PublishTrimmed=true"
+    Invoke-Step -Name "AOT smoke publish" -Command "dotnet publish samples/NativeData.AotSmoke/NativeData.AotSmoke.csproj -c Release -r $RuntimeIdentifier"
 }
 
 $artifactRoot = Join-Path -Path "artifacts" -ChildPath "release/$version"


### PR DESCRIPTION
## Summary

- Describe the change and why it is needed.

## Type of Change

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Docs
- [ ] Test
- [ ] Chore
- [ ] Release PR (use `release.md` template)

## Validation

- [ ] `dotnet build NativeData.slnx -warnaserror`
- [ ] `dotnet test NativeData.slnx`
- [ ] AOT smoke publish (if applicable)

## Notes

- Include any context reviewers should know.

---

If this is a release PR, open with template:

`?template=release.md`
