### PR TITLE
feat: analyzer rule ND0004 for runtime expression compilation

### DIFF
--- a/docs/analyzers/ND0004.md
+++ b/docs/analyzers/ND0004.md
@@ -1,0 +1,42 @@
+# ND0004: Avoid runtime expression compilation
+
+## Summary
+
+`ND0004` warns when code calls `Expression<TDelegate>.Compile()` or `LambdaExpression.Compile()`.
+
+## Why this matters
+
+- Runtime expression compilation depends on runtime code generation paths.
+- NativeAOT and aggressive trimming scenarios are designed around compile-time closure.
+- Query pipelines should favor compile-time generated translation instead of runtime delegate compilation.
+
+## Trigger examples
+
+```csharp
+Expression<Func<int>> expression = () => 42;
+var compiled = expression.Compile();
+```
+
+```csharp
+LambdaExpression expression = (Expression<Func<int>>)(() => 42);
+var compiled = expression.Compile();
+```
+
+## Recommended fixes
+
+Prefer one of these patterns:
+
+- Use compile-time generated query/predicate helpers.
+- Keep expression trees as data for translation rather than compiling to delegates at runtime.
+- Replace runtime compilation with explicit typed delegates when values are known at compile time.
+
+## Diagnostic details
+
+- **ID**: `ND0004`
+- **Category**: `NativeData.Compatibility`
+- **Default severity**: `Warning`
+- **Message**: `Runtime expression compilation via Compile() is not AOT/trimming-safe`
+
+## Suppression guidance
+
+Suppress only when runtime compilation is unavoidable and deployment targets are explicitly validated.

--- a/src/NativeData.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/NativeData.Analyzers/AnalyzerReleases.Unshipped.md
@@ -5,5 +5,6 @@ Rule ID | Category | Severity | Notes
 ND0001 | NativeData.Compatibility | Warning | Avoid runtime type loading via Type.GetType for AOT/trimming safety
 ND0002 | NativeData.Compatibility | Warning | Avoid runtime assembly loading via Assembly.Load(string) for AOT/trimming safety
 ND0003 | NativeData.Compatibility | Warning | Avoid string-based runtime activation via Activator.CreateInstance(string, string)
+ND0004 | NativeData.Compatibility | Warning | Avoid runtime expression compilation via Expression/LambdaExpression.Compile()
 ND1001 | NativeData.Mapping | Warning | NativeDataEntity key column must map to a public readable property
 ND1002 | NativeData.Mapping | Warning | NativeDataEntity tableName/keyColumn literals must be non-empty and non-whitespace

--- a/src/NativeData.Analyzers/README.md
+++ b/src/NativeData.Analyzers/README.md
@@ -16,6 +16,8 @@ Roslyn analyzer project for NativeData AOT/trimming safety diagnostics.
 	- Remediation: [docs/analyzers/ND0002.md](../../docs/analyzers/ND0002.md)
 - `ND0003` — Avoid string-based runtime activation (`Activator.CreateInstance(string, string)`)
 	- Remediation: [docs/analyzers/ND0003.md](../../docs/analyzers/ND0003.md)
+- `ND0004` — Avoid runtime expression compilation (`Expression.Compile()` / `LambdaExpression.Compile()`)
+	- Remediation: [docs/analyzers/ND0004.md](../../docs/analyzers/ND0004.md)
 - `ND1001` — NativeData entity key column must map to a public property
 	- Remediation: [docs/analyzers/ND1001.md](../../docs/analyzers/ND1001.md)
 - `ND1002` — NativeDataEntity `tableName`/`keyColumn` literals must be non-empty

--- a/src/NativeData.Analyzers/TrimSafetyAnalyzer.cs
+++ b/src/NativeData.Analyzers/TrimSafetyAnalyzer.cs
@@ -13,6 +13,7 @@ public sealed class TrimSafetyAnalyzer : DiagnosticAnalyzer
     public const string TypeGetTypeDiagnosticId = "ND0001";
     public const string AssemblyLoadDiagnosticId = "ND0002";
     public const string ActivatorCreateInstanceDiagnosticId = "ND0003";
+    public const string ExpressionCompileDiagnosticId = "ND0004";
     public const string DiagnosticId = TypeGetTypeDiagnosticId;
 
     private static readonly DiagnosticDescriptor TypeGetTypeRule = new(
@@ -42,7 +43,16 @@ public sealed class TrimSafetyAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         description: "Use compile-time known types instead of string-based Activator.CreateInstance overloads for AOT/trimming compliance.");
 
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [TypeGetTypeRule, AssemblyLoadRule, ActivatorCreateInstanceRule];
+    private static readonly DiagnosticDescriptor ExpressionCompileRule = new(
+        ExpressionCompileDiagnosticId,
+        "Avoid runtime expression compilation",
+        "Runtime expression compilation via Compile() is not AOT/trimming-safe",
+        "NativeData.Compatibility",
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Prefer compile-time generated query/predicate translation over Expression/LambdaExpression.Compile() for AOT/trimming compliance.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [TypeGetTypeRule, AssemblyLoadRule, ActivatorCreateInstanceRule, ExpressionCompileRule];
 
     public override void Initialize(AnalysisContext context)
     {
@@ -84,6 +94,15 @@ public sealed class TrimSafetyAnalyzer : DiagnosticAnalyzer
             symbol.Parameters[0].Type.SpecialType == SpecialType.System_String)
         {
             context.ReportDiagnostic(Diagnostic.Create(ActivatorCreateInstanceRule, invocation.GetLocation()));
+            return;
+        }
+
+        if (symbol.Name == "Compile" &&
+            symbol.ContainingType.ContainingNamespace.ToDisplayString() == "System.Linq.Expressions" &&
+            (symbol.ContainingType.Name == "LambdaExpression" ||
+             symbol.ContainingType.OriginalDefinition.ToDisplayString() == "System.Linq.Expressions.Expression<TDelegate>"))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(ExpressionCompileRule, invocation.GetLocation()));
         }
     }
 }

--- a/tests/NativeData.Tests/AnalyzerTests.cs
+++ b/tests/NativeData.Tests/AnalyzerTests.cs
@@ -130,6 +130,71 @@ public static class Demo
     }
 
     [Fact]
+    public async Task ND0004_ReportsDiagnostic_ForExpressionCompileUsage()
+    {
+        const string source = """
+using System;
+using System.Linq.Expressions;
+
+public static class Demo
+{
+    public static Func<int> Build()
+    {
+        Expression<Func<int>> expression = () => 42;
+        return expression.Compile();
+    }
+}
+""";
+
+        var diagnostics = await AnalyzeAsync(source);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == TrimSafetyAnalyzer.ExpressionCompileDiagnosticId);
+    }
+
+    [Fact]
+    public async Task ND0004_ReportsDiagnostic_ForLambdaExpressionCompileUsage()
+    {
+        const string source = """
+using System;
+using System.Linq.Expressions;
+
+public static class Demo
+{
+    public static Delegate Build()
+    {
+        LambdaExpression expression = (Expression<Func<int>>)(() => 42);
+        return expression.Compile();
+    }
+}
+""";
+
+        var diagnostics = await AnalyzeAsync(source);
+
+        Assert.Contains(diagnostics, diagnostic => diagnostic.Id == TrimSafetyAnalyzer.ExpressionCompileDiagnosticId);
+    }
+
+    [Fact]
+    public async Task ND0004_DoesNotReportDiagnostic_WhenCompileNotUsed()
+    {
+        const string source = """
+using System;
+using System.Linq.Expressions;
+
+public static class Demo
+{
+    public static Expression<Func<int>> Build()
+    {
+        return () => 42;
+    }
+}
+""";
+
+        var diagnostics = await AnalyzeAsync(source);
+
+        Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.Id == TrimSafetyAnalyzer.ExpressionCompileDiagnosticId);
+    }
+
+    [Fact]
     public async Task ND1001_ReportsDiagnostic_WhenNativeDataEntityKeyPropertyMissing()
     {
         const string source = """


### PR DESCRIPTION
Adds analyzer rule ND0004 to warn on runtime expression compilation using Expression<T>.Compile() and LambdaExpression.Compile().

Includes:
- ND0004 rule in TrimSafetyAnalyzer
- New analyzer tests for detection and no-compile baseline
- Analyzer README + release metadata update
- New remediation doc: docs/analyzers/ND0004.md

Closes #21

Validation:
- dotnet build NativeData.slnx -warnaserror
- dotnet test tests/NativeData.Tests/NativeData.Tests.csproj