### PR TITLE
Add expression/lambda-based Where for NativeDataQuery<T>

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -73,6 +73,9 @@ var product = await repo.GetByIdAsync(1);
 
 - Repository-style API (`IRepository<T>`)
 - CRUD operations: `GetByIdAsync`, `QueryAsync`, `InsertAsync`, `UpdateAsync`, `DeleteByIdAsync`
+- Fluent query builder (`NativeDataQuery<T>`) with `Where(Expression<Func<T,bool>>)` subset translation
+  - Supported operators: `==`, `!=`, `<`, `<=`, `>`, `>=`, `&&`, `||`, and parentheses
+  - Unsupported constructs throw `NotSupportedException` at query-build time
 - Provider-agnostic execution via ADO.NET abstractions
 - Dialect abstraction for identifier quoting and parameter normalization
 - SQLite provider package
@@ -83,7 +86,7 @@ var product = await repo.GetByIdAsync(1);
 
 - Migrations
 - Change tracking / identity map
-- LINQ translation/provider
+- Full LINQ provider/translation
 
 ## Documentation
 

--- a/docs/status-and-roadmap.md
+++ b/docs/status-and-roadmap.md
@@ -40,7 +40,7 @@ The full milestone backlog, priorities, and work item status are tracked in the 
 | v0.3.0 | Source-generated `IEntityMap<T>` end-to-end | ✅ Done |
 | v0.4.0 | Analyzer pack expansion (ND0001–ND1002) | ✅ Done |
 | v0.5.0 | Second provider — PostgreSQL (Npgsql) | ✅ Done |
-| v0.6.0 | LINQ-style fluent query builder (`NativeDataQuery<T>`) | 🔲 Planned |
+| v0.6.0 | LINQ-style fluent query builder (`NativeDataQuery<T>`) | ✅ Done |
 | v0.7.0 | `NativeDataContext` + DI integration (`AddNativeData<T>`) | 🔲 Planned |
 | v1.0.0 | API freeze, full docs, production baseline | 🔲 Planned |
 

--- a/src/NativeData.Core/ExpressionQueryFilterTranslator.cs
+++ b/src/NativeData.Core/ExpressionQueryFilterTranslator.cs
@@ -1,0 +1,238 @@
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using NativeData.Abstractions;
+
+namespace NativeData.Core;
+
+internal static class ExpressionQueryFilterTranslator<T>
+    where T : class
+{
+    public static QueryFilter Translate(
+        Expression<Func<T, bool>> predicate,
+        IEntityMap<T> entityMap,
+        ISqlDialect sqlDialect)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        ArgumentNullException.ThrowIfNull(entityMap);
+        ArgumentNullException.ThrowIfNull(sqlDialect);
+
+        var allowedColumns = new HashSet<string>(entityMap.WritableColumns, StringComparer.OrdinalIgnoreCase)
+        {
+            entityMap.KeyColumn,
+        };
+
+        var parameters = new List<SqlParameterValue>();
+        var parameterIndex = 0;
+        var sql = TranslateNode(predicate.Body, predicate.Parameters[0], allowedColumns, sqlDialect, parameters, ref parameterIndex);
+        return new QueryFilter(sql, parameters.Count == 0 ? null : parameters);
+    }
+
+    private static string TranslateNode(
+        Expression expression,
+        ParameterExpression parameter,
+        HashSet<string> allowedColumns,
+        ISqlDialect sqlDialect,
+        List<SqlParameterValue> parameters,
+        ref int parameterIndex)
+    {
+        expression = UnwrapConvert(expression);
+
+        return expression switch
+        {
+            BinaryExpression binary when binary.NodeType is ExpressionType.AndAlso or ExpressionType.OrElse
+                => TranslateLogical(binary, parameter, allowedColumns, sqlDialect, parameters, ref parameterIndex),
+            BinaryExpression binary when IsComparison(binary.NodeType)
+                => TranslateComparison(binary, parameter, allowedColumns, sqlDialect, parameters, ref parameterIndex),
+            _ => throw NotSupported(expression, "Only comparison and boolean operator expressions are supported."),
+        };
+    }
+
+    private static string TranslateLogical(
+        BinaryExpression binary,
+        ParameterExpression parameter,
+        HashSet<string> allowedColumns,
+        ISqlDialect sqlDialect,
+        List<SqlParameterValue> parameters,
+        ref int parameterIndex)
+    {
+        var op = binary.NodeType == ExpressionType.AndAlso ? "AND" : "OR";
+        var left = TranslateNode(binary.Left, parameter, allowedColumns, sqlDialect, parameters, ref parameterIndex);
+        var right = TranslateNode(binary.Right, parameter, allowedColumns, sqlDialect, parameters, ref parameterIndex);
+        return $"({left} {op} {right})";
+    }
+
+    private static string TranslateComparison(
+        BinaryExpression binary,
+        ParameterExpression parameter,
+        HashSet<string> allowedColumns,
+        ISqlDialect sqlDialect,
+        List<SqlParameterValue> parameters,
+        ref int parameterIndex)
+    {
+        var left = UnwrapConvert(binary.Left);
+        var right = UnwrapConvert(binary.Right);
+
+        if (TryGetColumn(left, parameter, allowedColumns, out var column))
+        {
+            return BuildComparison(column, binary.NodeType, right, sqlDialect, parameters, ref parameterIndex);
+        }
+
+        if (TryGetColumn(right, parameter, allowedColumns, out column))
+        {
+            return BuildComparison(column, ReverseComparison(binary.NodeType), left, sqlDialect, parameters, ref parameterIndex);
+        }
+
+        throw NotSupported(binary, "One side of each comparison must reference an entity column.");
+    }
+
+    private static string BuildComparison(
+        string column,
+        ExpressionType comparisonType,
+        Expression valueExpression,
+        ISqlDialect sqlDialect,
+        List<SqlParameterValue> parameters,
+        ref int parameterIndex)
+    {
+        if (!TryEvaluateValue(valueExpression, out var value))
+        {
+            throw NotSupported(valueExpression, "Comparison value must be a constant or captured value.");
+        }
+
+        var quotedColumn = sqlDialect.QuoteIdentifier(column);
+
+        if (value is null)
+        {
+            return comparisonType switch
+            {
+                ExpressionType.Equal => $"{quotedColumn} IS NULL",
+                ExpressionType.NotEqual => $"{quotedColumn} IS NOT NULL",
+                _ => throw NotSupported(valueExpression, "Null comparisons only support == and !=."),
+            };
+        }
+
+        var parameterName = $"p{parameterIndex++}";
+        var sqlParameterName = sqlDialect.BuildParameterName(parameterName);
+        parameters.Add(new SqlParameterValue(parameterName, value));
+        return $"{quotedColumn} {ToSqlComparison(comparisonType)} {sqlParameterName}";
+    }
+
+    private static bool TryGetColumn(
+        Expression expression,
+        ParameterExpression parameter,
+        HashSet<string> allowedColumns,
+        out string column)
+    {
+        column = string.Empty;
+        expression = UnwrapConvert(expression);
+
+        if (expression is not MemberExpression member || !IsParameterMember(member.Expression, parameter))
+        {
+            return false;
+        }
+
+        if (!allowedColumns.Contains(member.Member.Name))
+        {
+            throw NotSupported(expression, $"Member '{member.Member.Name}' is not a mapped column.");
+        }
+
+        column = member.Member.Name;
+        return true;
+    }
+
+    private static bool IsParameterMember(Expression? expression, ParameterExpression parameter)
+    {
+        return expression is not null && UnwrapConvert(expression) == parameter;
+    }
+
+    private static bool TryEvaluateValue(Expression expression, out object? value)
+    {
+        expression = UnwrapConvert(expression);
+
+        switch (expression)
+        {
+            case ConstantExpression constant:
+                value = constant.Value;
+                return true;
+            case MemberExpression member:
+                object? target;
+                if (member.Expression is null)
+                {
+                    target = null;
+                }
+                else if (!TryEvaluateValue(member.Expression, out target))
+                {
+                    value = null;
+                    return false;
+                }
+
+                switch (member.Member)
+                {
+                    case FieldInfo field:
+                        value = field.GetValue(target);
+                        return true;
+                    case PropertyInfo property:
+                        value = property.GetValue(target);
+                        return true;
+                    default:
+                        value = null;
+                        return false;
+                }
+            default:
+                value = null;
+                return false;
+        }
+    }
+
+    private static Expression UnwrapConvert(Expression expression)
+    {
+        while (expression is UnaryExpression unary &&
+               (unary.NodeType == ExpressionType.Convert || unary.NodeType == ExpressionType.ConvertChecked))
+        {
+            expression = unary.Operand;
+        }
+
+        return expression;
+    }
+
+    private static bool IsComparison(ExpressionType nodeType)
+    {
+        return nodeType is ExpressionType.Equal or
+               ExpressionType.NotEqual or
+               ExpressionType.GreaterThan or
+               ExpressionType.GreaterThanOrEqual or
+               ExpressionType.LessThan or
+               ExpressionType.LessThanOrEqual;
+    }
+
+    private static ExpressionType ReverseComparison(ExpressionType nodeType)
+    {
+        return nodeType switch
+        {
+            ExpressionType.GreaterThan => ExpressionType.LessThan,
+            ExpressionType.GreaterThanOrEqual => ExpressionType.LessThanOrEqual,
+            ExpressionType.LessThan => ExpressionType.GreaterThan,
+            ExpressionType.LessThanOrEqual => ExpressionType.GreaterThanOrEqual,
+            _ => nodeType,
+        };
+    }
+
+    private static string ToSqlComparison(ExpressionType nodeType)
+    {
+        return nodeType switch
+        {
+            ExpressionType.Equal => "=",
+            ExpressionType.NotEqual => "<>",
+            ExpressionType.GreaterThan => ">",
+            ExpressionType.GreaterThanOrEqual => ">=",
+            ExpressionType.LessThan => "<",
+            ExpressionType.LessThanOrEqual => "<=",
+            _ => throw new NotSupportedException($"Unsupported comparison operator '{nodeType}'."),
+        };
+    }
+
+    private static NotSupportedException NotSupported(Expression expression, string reason)
+    {
+        return new NotSupportedException($"Unsupported predicate expression '{expression}': {reason}");
+    }
+}

--- a/src/NativeData.Core/NativeDataQuery.cs
+++ b/src/NativeData.Core/NativeDataQuery.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,6 +40,22 @@ public sealed class NativeDataQuery<T>
     public NativeDataQuery<T> Where(QueryFilter filter)
     {
         _where = filter;
+        return this;
+    }
+
+    /// <summary>
+    /// Filters results using a bounded expression subset and translates it to SQL without runtime compilation.
+    /// Replaces any previously set filter.
+    /// </summary>
+    /// <param name="predicate">
+    /// Predicate composed of comparison operators (<c>==</c>, <c>!=</c>, <c>&lt;</c>, <c>&lt;=</c>, <c>&gt;</c>, <c>&gt;=</c>)
+    /// and boolean operators (<c>&amp;&amp;</c>, <c>||</c>).
+    /// </param>
+    /// <returns>This query builder for chaining.</returns>
+    /// <exception cref="NotSupportedException">Thrown when the predicate uses unsupported constructs.</exception>
+    public NativeDataQuery<T> Where(Expression<Func<T, bool>> predicate)
+    {
+        _where = ExpressionQueryFilterTranslator<T>.Translate(predicate, _entityMap, _sqlDialect);
         return this;
     }
 

--- a/tests/NativeData.Tests/NativeDataQueryTests.cs
+++ b/tests/NativeData.Tests/NativeDataQueryTests.cs
@@ -34,6 +34,45 @@ public class NativeDataQueryTests
     }
 
     [Fact]
+    public async Task ToListAsync_WithExpressionWhere_TranslatesToParameterizedSql()
+    {
+        var executor = new CapturingExecutor([new TestEntity(1, "Alice")]);
+        var repo = new SqlRepository<TestEntity>(executor, new TestEntityMap());
+        var name = "Alice";
+
+        await repo.Query().Where(e => e.Name == name).ToListAsync();
+
+        Assert.Contains("WHERE [Name] = @p0", executor.LastCommandText);
+        Assert.NotNull(executor.LastParameters);
+        Assert.Single(executor.LastParameters!);
+        Assert.Equal("Alice", executor.LastParameters[0].Value);
+    }
+
+    [Fact]
+    public async Task ToListAsync_WithExpressionWhere_TranslatesComparisonAndBooleanOperators()
+    {
+        var executor = new CapturingExecutor([]);
+        var repo = new SqlRepository<TestEntity>(executor, new TestEntityMap());
+
+        await repo.Query().Where(e => e.Id >= 10 && (e.Id < 20 || e.Name != "blocked")).ToListAsync();
+
+        Assert.Contains("WHERE ([Id] >= @p0 AND ([Id] < @p1 OR [Name] <> @p2))", executor.LastCommandText);
+        Assert.NotNull(executor.LastParameters);
+        Assert.Equal(3, executor.LastParameters!.Count);
+    }
+
+    [Fact]
+    public void Where_WithExpressionWhere_ThrowsForUnsupportedConstructs()
+    {
+        var executor = new CapturingExecutor([]);
+        var repo = new SqlRepository<TestEntity>(executor, new TestEntityMap());
+
+        var ex = Assert.Throws<NotSupportedException>(() => repo.Query().Where(e => e.Name.StartsWith("A")));
+
+        Assert.Contains("Unsupported predicate expression", ex.Message);
+    }
+
+    [Fact]
     public async Task ToListAsync_WithOrderBy_AppendsOrderByClause()
     {
         var executor = new CapturingExecutor([]);
@@ -153,6 +192,7 @@ public class NativeDataQueryTests
     private sealed class CapturingExecutor(IReadOnlyList<TestEntity> rows) : ICommandExecutor
     {
         public string? LastCommandText { get; private set; }
+        public IReadOnlyList<SqlParameterValue>? LastParameters { get; private set; }
 
         public ValueTask<int> ExecuteAsync(
             string commandText,
@@ -160,6 +200,7 @@ public class NativeDataQueryTests
             CancellationToken cancellationToken = default)
         {
             LastCommandText = commandText;
+            LastParameters = parameters;
             return ValueTask.FromResult(rows.Count);
         }
 
@@ -170,6 +211,7 @@ public class NativeDataQueryTests
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             LastCommandText = commandText;
+            LastParameters = parameters;
             foreach (var row in rows)
             {
                 await Task.CompletedTask;


### PR DESCRIPTION
## Summary
- add NativeDataQuery<T>.Where(Expression<Func<T, bool>>) overload
- translate bounded expression subset (==, !=, <, <=, >, >=, &&, ||, parentheses) to parameterized SQL
- throw NotSupportedException for unsupported constructs
- add query translation tests and update docs/roadmap status

Closes #62